### PR TITLE
Fix docker-compose to build image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
-  endee-oss:
-    image: endee-oss:latest
-    container_name: endee-oss
+  endee:
+    image: endeeio/endee-server:latest
+    container_name: endee-server
     ports:
       - "8080:8080"
     ulimits:


### PR DESCRIPTION
This PR updates docker-compose.yml to build the image instead of attempting to pull a non-existent image.