### PR TITLE
fix(deletion): fix hybrid index deletion bug

### DIFF
--- a/src/core/ndd.hpp
+++ b/src/core/ndd.hpp
@@ -1435,6 +1435,12 @@ public:
                 // Mark as deleted in HNSW index
                 entry.alg->markDelete(numeric_id);
             }
+            
+            // Delete from sparse storage if it exists
+            if(entry.sparse_storage) {
+                 entry.sparse_storage->delete_vectors_batch(numeric_ids);
+            }
+
             // Add the list to write ahead log using IndexManager's method
             logDeletions(entry.index_id, numeric_ids);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -666,6 +666,11 @@ int main(int argc, char** argv) {
                                 vec.sparse_values.push_back(static_cast<float>(v.d()));
                             }
                         }
+                        
+                        if(item.has("metadata")) {
+                             crow::json::wvalue col(item["metadata"]);
+                             vec.filter = col.dump();
+                        }
                         return vec;
                     };
 


### PR DESCRIPTION
# Fix: Deleted Vectors Returned in Hybrid Index Query

## Summary

Fixes a bug where vectors deleted using `delete_with_filter` were still persisting in the sparse index and returning in hybrid search results. This PR addresses two underlying causes: metadata parsing failures during insertion and incomplete deletion logic for sparse vectors.

**Fixes #10**

## Changes

### 1. Fix Metadata Parsing (`src/main.cpp`)

The vector insertion endpoint (`/vector/insert`) was ignoring the `metadata` field in the request body. This prevented vectors from having searchable attributes, meaning subsequent `delete_with_filter` operations (e.g., `{"visibility": "public"}`) matched zero vectors.

- **Change**: Updated `parse_obj` lambda to correctly extract and store the `metadata` JSON field into the vector's `filter` property.

### 2. Implement Sparse Deletion (`src/core/ndd.hpp`)

The `deleteVectorsByIds` function was only removing vectors from the HNSW (dense) index. Since hybrid search combines results from both dense and sparse indexes, the "deleted" vectors were still being found via the sparse index.

- **Change**: Added logic to check for `sparse_storage` existence and call `delete_vectors_batch` to explicitly remove vectors from the sparse database transactionally.

## Verification

Verified using a reproduction script (provided in issue #10) which:

1. Creates a hybrid index.
2. Inserts 50 "public" and 50 "private" vectors.
3. Deletes "public" vectors using a filter.
4. Queries for "public" vectors.

**Results:**

- **Before Fix**: Query returned 4+ "public" vectors (deleted vectors reappeared).
- **After Fix**: Query returns **0 results**, confirming vectors are correctly identified and fully removed from both index components.
