### PR TITLE
quantization optimization and bug fixes

### DIFF
--- a/src/quant/binary.hpp
+++ b/src/quant/binary.hpp
@@ -28,7 +28,7 @@ namespace ndd {
             }
 
             // No scale for binary quantization
-            inline float extract_inv_scale(const uint8_t* buffer, size_t dimension) {
+            inline float extract_scale(const uint8_t* buffer, size_t dimension) {
                 return 1.0f;
             }
 
@@ -666,7 +666,7 @@ namespace ndd {
                 d.dequantize = &binary::dequantize;
                 d.quantize_to_int8 = &binary::quantize_to_int8;
                 d.get_storage_size = &binary::get_storage_size;
-                d.extract_inv_scale = &binary::extract_inv_scale;
+                d.extract_scale = &binary::extract_scale;
                 return d;
             }
         };

--- a/src/quant/common.hpp
+++ b/src/quant/common.hpp
@@ -28,7 +28,6 @@ namespace ndd {
             FP32 = 32,   // Full precision float (4 bytes per dimension)
             INT16 = 16,  // Dynamic 16-bit integer quantization
             FP16 = 15,   // Half precision float (2 bytes per dimension)
-            INT4 = 5,    // Dynamic 4-bit integer quantization
             BINARY = 1,  // Binary quantization (1 bit per dimension)
             INT8 = 8,    // Dynamic 8-bit integer quantization
             UNKNOWN = 0
@@ -55,7 +54,7 @@ namespace ndd {
 
             // Metadata
             size_t (*get_storage_size)(size_t dim);
-            float (*extract_inv_scale)(const uint8_t* in, size_t dim);
+            float (*extract_scale)(const uint8_t* in, size_t dim);
         };
 
         // Abstract base class for Quantization implementations

--- a/src/quant/float16.hpp
+++ b/src/quant/float16.hpp
@@ -16,7 +16,7 @@ namespace ndd {
                 return dimension * sizeof(uint16_t);
             }
 
-            inline float extract_inv_scale(const uint8_t* in, size_t dim) {
+            inline float extract_scale(const uint8_t* in, size_t dim) {
                 return 1.0f;
             }
 
@@ -1083,7 +1083,7 @@ namespace ndd {
                 d.dequantize = &float16::dequantize;
                 d.quantize_to_int8 = &float16::quantize_to_int8;
                 d.get_storage_size = &float16::get_storage_size;
-                d.extract_inv_scale = &float16::extract_inv_scale;
+                d.extract_scale = &float16::extract_scale;
                 return d;
             }
         };

--- a/src/quant/float32.hpp
+++ b/src/quant/float32.hpp
@@ -42,7 +42,7 @@ namespace hnswlib {
                 return result;
             }
 
-            inline float extract_inv_scale(const uint8_t* in, size_t dim) {
+            inline float extract_scale(const uint8_t* in, size_t dim) {
                 return 1.0f;
             }
 
@@ -555,7 +555,7 @@ namespace ndd {
                 d.dequantize = &hnswlib::quant::float32::dequantize;
                 d.quantize_to_int8 = &hnswlib::quant::float32::quantize_to_int8;
                 d.get_storage_size = [](size_t dim) { return dim * sizeof(float); };
-                d.extract_inv_scale = &hnswlib::quant::float32::extract_inv_scale;
+                d.extract_scale = &hnswlib::quant::float32::extract_scale;
                 return d;
             }
         };


### PR DESCRIPTION
int8d and int16d has a bug in de-quantization in scale. This means that when we fetch original vectors we will not get correct values.