### PR TITLE
return values for all functions in the codebase

### DIFF
--- a/src/utils/types.hpp
+++ b/src/utils/types.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <variant>
+
+namespace ndd {
+
+template <typename T = std::monostate>
+struct OperationResult {
+    unsigned int code = 0;
+    std::string message;
+    std::optional<T> value;
+
+    bool ok() const { return code == 0; }
+};
+
+}  // namespace ndd


### PR DESCRIPTION
**PR Title**

Add shared `OperationResult` type for explicit error propagation

**PR Body**

## Summary

This PR introduces a shared `ndd::OperationResult<T>` type in `src/utils/types.hpp`.

`OperationResult` is intended to become the standard lightweight return type for operations that need to report success or failure without throwing exceptions. It supports both status-only functions and functions that return a value.

```cpp
ndd::OperationResult<> status;
ndd::OperationResult<ndd::RoaringBitmap> bitmap_result;
```

## Why

Several parts of the codebase currently handle errors inconsistently: some functions throw, some log and continue, and some return fallback values like `false` or an empty bitmap even when the real issue is a storage failure.

That makes it hard for callers to distinguish between valid empty results and actual failures.

`OperationResult` gives us a common pattern for propagating errors upward so callers can decide whether to log, retry, return an API error, or abort the current operation.

## Design

`OperationResult<T>` contains:

- `code`: `0` means success; non-zero codes are operation-specific.
- `message`: optional human-readable failure context.
- `value`: optional result payload for functions that return data.
- `ok()`: convenience helper for success checks.

The default type is `std::monostate`, so status-only operations can use:

```cpp
ndd::OperationResult<> result;
```

## Future Usage

Follow-up changes will use this type across the filter subsystem first, especially for paths that currently swallow failures or return ambiguous defaults.

Examples:

```cpp
ndd::OperationResult<> add_filters_from_json_batch(...);

ndd::OperationResult<ndd::RoaringBitmap>
computeFilterBitmap(...);
```

Each function using `OperationResult` should document its local result codes above the function definition. Callers will use those codes to map failures to logs and API responses.

For example:

```cpp
// Result codes:
// 0 = success
// 1 = invalid filter JSON
// 2 = unsupported field type
// 100 = MDBX write failure
ndd::OperationResult<> add_filters_from_json_batch(...);
```

## Notes

This PR only adds the shared type. It does not yet change filter behavior or API error handling. Subsequent PRs will wire this into filter writes, reads, MDBX error paths, logging, and API response mapping.