### PR TITLE
Fix docker-compose to use infra/Dockerfile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,35 +1,21 @@
 services:
   endee-oss:
-    image: endee-oss:latest
+    build:
+      context: .
+      dockerfile: infra/Dockerfile
     container_name: endee-oss
     ports:
       - "8080:8080"
     ulimits:
       nofile: 100000
-# ----------------------------------------------------
-# Logging Configuration Block
     logging:
-      driver: "json-file" # Explicitly use the default driver
+      driver: "json-file"
       options:
-        # Set the max size of a single log file to 200 megabytes
-        # Docker rotates the log file when it hits this limit
         max-size: "200m"
-        # Set the maximum number of log files to keep
-        # (200m * 5 files = 1000m or 1 GB total log space)
         max-file: "5"
-# ----------------------------------------------------
     environment:
       NDD_NUM_THREADS: 0
-      NDD_AUTH_TOKEN: "" # Replace with your auth token
+      NDD_AUTH_TOKEN: ""
     volumes:
       - endee-data:/data
     restart: unless-stopped
-
-volumes:
-  # Modify the 'device' path below to change the host directory used for data persistence
-  endee-data:
-    # driver: local
-    # driver_opts:
-    # type: ext4
-    # o: bind
-    # device: ${PWD}/dockerdata


### PR DESCRIPTION
# Pull Request

## Summary

Fixes the Docker build configuration in `docker-compose.yml`.
The file previously used a prebuilt image (`endee-oss:latest`), but no such image is provided.
This update ensures Docker Compose correctly builds the service using the existing `infra/Dockerfile`.

## Type of Change

* [x] Bug fix
* [ ] New feature
* [ ] Breaking change
* [ ] Documentation update
* [ ] Refactor / cleanup

## Related Issue

Closes #

## Checklist

* [x] Code compiles and tests pass
* [ ] New tests added where applicable
* [x] Documentation updated if needed
* [x] No unintended breaking changes
