### PR TITLE
added custom error handling utility

### DIFF
--- a/src/core/ndd.hpp
+++ b/src/core/ndd.hpp
@@ -14,6 +14,7 @@
 #include "quant_vector.hpp"
 #include "wal.hpp"
 #include "../quant/dispatch.hpp"
+#include "../utils/errors.hpp"
 #include <memory>
 #include <deque>
 #include <unordered_map>
@@ -425,7 +426,7 @@ private:
             }
             it = indices_.find(index_id);
             if(it == indices_.end()) {
-                throw std::runtime_error("[ERROR] Index " + index_id + " doesnt exist.");
+                throw ndd::ApiError(404, "[ERROR] Index " + index_id + " doesnt exist.");
             }
             auto entry = it->second;
             per_thread_indices_[index_id] = entry;
@@ -830,13 +831,13 @@ public:
 
         if(!std::filesystem::exists(index_path) || !std::filesystem::exists(lmdb_dir)
            || !std::filesystem::exists(vector_storage_dir)) {
-            throw std::runtime_error("Required files missing for index: " + index_id);
+            throw ndd::ApiError(404, "Required files missing for index: " + index_id);
         }
 
         // Load metadata to get sparse_model
         auto metadata = metadata_manager_->getMetadata(index_id);
         if(!metadata) {
-            throw std::runtime_error("Missing or incompatible index metadata for index: "
+            throw ndd::ApiError(404, "Missing or incompatible index metadata for index: "
                                      + index_id);
         }
         const ndd::SparseScoringModel sparse_model = metadata->sparse_model;
@@ -1895,21 +1896,21 @@ public:
     // ========== Backup operations ==========
 
     // Orchestration methods (defined below after class)
-    std::pair<bool, std::string> createBackupAsync(const std::string& index_id,
-                                                    const std::string& backup_name);
+    std::string createBackupAsync(const std::string& index_id,
+                                  const std::string& backup_name);
 
-    std::pair<bool, std::string> restoreBackup(const std::string& backup_name,
-                                                const std::string& target_index_name,
-                                                const std::string& username);
+    void restoreBackup(const std::string& backup_name,
+                       const std::string& target_index_name,
+                       const std::string& username);
 
     // Forwarding methods (no IndexManager internals needed)
     nlohmann::json listBackups(const std::string& username) {
         return backup_store_.listBackups(username);
     }
 
-    std::pair<bool, std::string> deleteBackup(const std::string& backup_name,
-                                               const std::string& username) {
-        return backup_store_.deleteBackup(backup_name, username);
+    void deleteBackup(const std::string& backup_name,
+                      const std::string& username) {
+        backup_store_.deleteBackup(backup_name, username);
     }
 
     std::optional<std::pair<std::string, std::string>> getActiveBackup(const std::string& username) {
@@ -1921,13 +1922,13 @@ public:
         return backup_store_.getBackupInfo(backup_name, username);
     }
 
-    std::pair<bool, std::string> validateBackupName(const std::string& backup_name) const {
-        return backup_store_.validateBackupName(backup_name);
+    void validateBackupName(const std::string& backup_name) const {
+        backup_store_.validateBackupName(backup_name);
     }
 
-    std::pair<bool, std::string> uploadBackup(const std::string& backup_name,
-                                                const std::string& username,
-                                                const std::string& file_content);
+    void uploadBackup(const std::string& backup_name,
+                      const std::string& username,
+                      const std::string& file_content);
 };
 
 // ========== IndexManager backup implementations ==========
@@ -2094,13 +2095,10 @@ inline void IndexManager::executeBackupJob(const std::string& index_id, const st
     }
 }
 
-inline std::pair<bool, std::string> IndexManager::restoreBackup(const std::string& backup_name,
-                                                                  const std::string& target_index_name,
-                                                                  const std::string& username) {
-    std::pair<bool, std::string> result = backup_store_.validateBackupName(backup_name);
-    if(!result.first) {
-        return result;
-    }
+inline void IndexManager::restoreBackup(const std::string& backup_name,
+                                        const std::string& target_index_name,
+                                        const std::string& username) {
+    backup_store_.validateBackupName(backup_name);
 
     std::string backup_dir_root = backup_store_.getUserBackupDir(username);
     std::string backup_tar = backup_dir_root + "/" + backup_name + ".tar";
@@ -2111,16 +2109,16 @@ inline std::pair<bool, std::string> IndexManager::restoreBackup(const std::strin
     std::string target_dir = data_dir_ + "/" + target_index_id;
 
     if(!std::filesystem::exists(backup_tar)) {
-        return {false, "Backup not found: " + backup_name};
+        throw ndd::ApiError(404, "Backup not found: " + backup_name);
     }
 
     if(metadata_manager_->getMetadata(target_index_id).has_value()) {
-        return {false, "Target index already exists"};
+        throw ndd::ApiError(409, "Target index already exists");
     }
 
     std::string error_msg;
     if(!backup_store_.extractBackupTar(backup_tar, backup_extract_dir, error_msg)) {
-        return {false, "Failed to extract backup archive: " + error_msg};
+        throw ndd::ApiError(500, "Failed to extract backup archive: " + error_msg);
     }
 
     std::vector<std::string> folders;
@@ -2132,7 +2130,7 @@ inline std::pair<bool, std::string> IndexManager::restoreBackup(const std::strin
 
     if(folders.size() != 1) {
         std::filesystem::remove_all(backup_extract_dir);
-        return {false, "Backup extraction failed - directory not found"};
+        throw ndd::ApiError(500, "Backup extraction failed - directory not found");
     }
 
     std::string backup_dir = folders[0];
@@ -2141,7 +2139,7 @@ inline std::pair<bool, std::string> IndexManager::restoreBackup(const std::strin
         std::ifstream f(backup_dir + "/metadata.json");
         if(!f.good()) {
             std::filesystem::remove_all(backup_extract_dir);
-            return {false, "Backup metadata missing"};
+            throw ndd::ApiError(500, "Backup metadata missing");
         }
         nlohmann::json meta_json = nlohmann::json::parse(f);
 
@@ -2178,37 +2176,33 @@ inline std::pair<bool, std::string> IndexManager::restoreBackup(const std::strin
         }
 
         LOG_INFO(2045, username, target_index_name, "Restored backup from " << backup_tar);
-        return {true, ""};
     } catch(const std::exception& e) {
         std::filesystem::remove_all(backup_extract_dir);
-        return {false, "Failed to restore backup: " + std::string(e.what())};
+        throw ndd::ApiError(500, "Failed to restore backup: " + std::string(e.what()));
     }
 }
 
-inline std::pair<bool, std::string> IndexManager::createBackupAsync(const std::string& index_id,
-                                                                      const std::string& backup_name) {
-    std::pair<bool, std::string> result = backup_store_.validateBackupName(backup_name);
-    if(!result.first) {
-        return result;
-    }
+inline std::string IndexManager::createBackupAsync(const std::string& index_id,
+                                                   const std::string& backup_name) {
+    backup_store_.validateBackupName(backup_name);
 
     std::string username;
     size_t pos = index_id.find('/');
     if (pos != std::string::npos) {
         username = index_id.substr(0, pos);
     } else {
-        return {false, "Invalid index ID format"};
+        throw ndd::ApiError(400, "Invalid index ID format");
     }
 
     if (backup_store_.hasActiveBackup(username)) {
-        return {false, "Backup already in progress for user: " + username};
+        throw ndd::ApiError(409, "Backup already in progress for user: " + username);
     }
 
     std::string user_backup_dir = backup_store_.getUserBackupDir(username);
     std::filesystem::create_directories(user_backup_dir);
     std::string backup_tar = user_backup_dir + "/" + backup_name + ".tar";
     if (std::filesystem::exists(backup_tar)) {
-        return {false, "Backup already exists: " + backup_name};
+        throw ndd::ApiError(409, "Backup already exists: " + backup_name);
     }
 
     std::jthread t([this, index_id, backup_name](std::stop_token st) {
@@ -2218,23 +2212,23 @@ inline std::pair<bool, std::string> IndexManager::createBackupAsync(const std::s
 
     LOG_INFO(2046, index_id, "Backup started: " << backup_name);
 
-    return {true, backup_name};
+    return backup_name;
 }
 
-inline std::pair<bool, std::string> IndexManager::uploadBackup(const std::string& backup_name, const std::string& username, const std::string& file_content) {
+inline void IndexManager::uploadBackup(const std::string& backup_name, const std::string& username, const std::string& file_content) {
     std::string user_backup_dir = backup_store_.getUserBackupDir(username);
     std::filesystem::create_directories(user_backup_dir);
     std::string backup_path = user_backup_dir + "/" + backup_name + ".tar";
     if(std::filesystem::exists(backup_path)) {
         LOG_WARN(1063, username, "Backup upload conflicts with existing backup " << backup_name);
         
-        return {false, "Backup with name '" + backup_name +"' already exits"};
+        throw ndd::ApiError(409, "Backup with name '" + backup_name +"' already exits");
     }
 
     // Write the file
     std::ofstream out(backup_path, std::ios::binary);
     if(!out.is_open()) {
-        return {false, "Failed to create backup file"};
+        throw ndd::ApiError(500, "Failed to create backup file");
     }
 
     out.write(file_content.data(), file_content.size());
@@ -2243,7 +2237,7 @@ inline std::pair<bool, std::string> IndexManager::uploadBackup(const std::string
     if(!out.good()) {
         // Clean up partial file on error
         std::filesystem::remove(backup_path);
-        return {false, "Failed to write backup file"};
+        throw ndd::ApiError(500, "Failed to write backup file");
     }
 
     nlohmann::json backup_json;
@@ -2278,6 +2272,4 @@ inline std::pair<bool, std::string> IndexManager::uploadBackup(const std::string
     nlohmann::json backup_db = backup_store_.readBackupJson(username);
     backup_db[backup_name] = backup_json;
     backup_store_.writeBackupJson(username, backup_db);
-
-    return {true, "Backup uploaded successfully"};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,6 +38,7 @@
 #include "auth.hpp"
 #include "quant/common.hpp"
 #include "system_sanity/system_sanity.hpp"
+#include "utils/errors.hpp"
 
 using ndd::quant::quantLevelToString;
 using ndd::quant::stringToQuantLevel;
@@ -443,6 +444,9 @@ int main(int argc, char** argv) {
                     // Pass the full index_id to index_manager using the Admin user type
                     index_manager.createIndex(index_id, config, UserType::Admin, size_in_millions);
                     return crow::response(200, "Index created successfully");
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1026, index_id, "Create-index request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1026, index_id, "Create-index request failed: " << e.what());
                     return json_error(409, e.what());
@@ -469,18 +473,16 @@ int main(int argc, char** argv) {
                 std::string index_id = ctx.username + "/" + index_name;
 
                 try {
-                    std::pair<bool, std::string> result =
-                            index_manager.createBackupAsync(index_id, backup_name);
-                    if(!result.first) {
-                        LOG_WARN(1021, ctx.username, index_name, "Create-backup request rejected: " << result.second);
-                        return json_error(400, result.second);
-                    }
+                    std::string backup_job = index_manager.createBackupAsync(index_id, backup_name);
 
                     // Return 202 Accepted with backup_name as job_id
                     crow::json::wvalue response;
-                    response["backup_name"] = result.second;
+                    response["backup_name"] = backup_job;
                     response["status"] = "in_progress";
                     return crow::response(202, response.dump());
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1021, ctx.username, index_name, "Create-backup request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::exception& e) {
                     return json_error_500(ctx.username, index_name, req.url, e.what());
                 }
@@ -520,13 +522,11 @@ int main(int argc, char** argv) {
                 std::string target_index_name = body["target_index_name"].s();
 
                 try {
-                    std::pair<bool, std::string> result =
-                            index_manager.restoreBackup(backup_name, target_index_name, ctx.username);
-                    if(!result.first) {
-                        LOG_WARN(1023, ctx.username, target_index_name, "Restore-backup request rejected: " << result.second);
-                        return json_error(400, result.second);
-                    }
+                    index_manager.restoreBackup(backup_name, target_index_name, ctx.username);
                     return crow::response(201, "Backup restored successfully");
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1023, ctx.username, target_index_name, "Restore-backup request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::exception& e) {
                     return json_error_500(ctx.username, target_index_name, req.url, e.what());
                 }
@@ -539,12 +539,11 @@ int main(int argc, char** argv) {
                                                              const std::string& backup_name) {
                 auto& ctx = app.get_context<AuthMiddleware>(req);
                 try {
-                    std::pair<bool, std::string> result = index_manager.deleteBackup(backup_name, ctx.username);
-                    if(!result.first) {
-                        LOG_WARN(1024, ctx.username, "Delete-backup request rejected: " << result.second);
-                        return json_error(400, result.second);
-                    }
+                    index_manager.deleteBackup(backup_name, ctx.username);
                     return crow::response(204, "Backup deleted successfully");
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1024, ctx.username, "Delete-backup request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::exception& e) {
                     return json_error_500(ctx.username, req.url, e.what());
                 }
@@ -631,19 +630,14 @@ int main(int argc, char** argv) {
                     }
 
                     // Validate backup name
-                    std::pair<bool, std::string> result =
-                            index_manager.validateBackupName(backup_name);
-                    if(!result.first) {
-                        LOG_WARN(1062, ctx.username, "Backup upload request rejected: " << result.second);
-                        return json_error(400, result.second);
-                    }
+                    index_manager.validateBackupName(backup_name);
 
-                    std::pair<bool, std::string> uploadStatus = index_manager.uploadBackup(backup_name, ctx.username, file_content);
-                    if(!uploadStatus.first) {
-                        return json_error(500, uploadStatus.second);
-                    }
+                    index_manager.uploadBackup(backup_name, ctx.username, file_content);
 
                     return crow::response(201, "Backup uploaded successfully");
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1062, ctx.username, "Backup upload request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::exception& e) {
                     return json_error_500(ctx.username, req.url, e.what());
                 }
@@ -729,6 +723,9 @@ int main(int argc, char** argv) {
                         LOG_WARN(1030, ctx.username, index_name, "Delete-index request for missing index");
                         return json_error(404, "Index not found");
                     }
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1031, ctx.username, index_name, "Delete-index request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1031, ctx.username, index_name, "Delete-index request rejected: " << e.what());
                     return json_error(400, e.what());
@@ -865,6 +862,9 @@ int main(int argc, char** argv) {
                     crow::response resp(200, std::string(sbuf.data(), sbuf.size()));
                     resp.add_header("Content-Type", "application/msgpack");
                     return resp;
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1039, ctx.username, index_name, "Search request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1039, ctx.username, index_name, "Search request rejected: " << e.what());
                     return json_error(400, e.what());
@@ -964,6 +964,9 @@ int main(int argc, char** argv) {
                             return json_error(400, "Batch insertion failed");
                         }
                         return crow::response(200);
+                    } catch(const ndd::ApiError& e) {
+                        LOG_WARN(1041, ctx.username, index_name, "Insert request rejected: " << e.what());
+                        return json_error(e.status_code(), e.what());
                     } catch(const std::runtime_error& e) {
                         LOG_WARN(1041, ctx.username, index_name, "Insert request rejected: " << e.what());
                         return json_error(400, e.what());
@@ -1003,6 +1006,9 @@ int main(int argc, char** argv) {
                             }
                             return crow::response(200);
                         }
+                    } catch(const ndd::ApiError& e) {
+                        LOG_WARN(1042, ctx.username, index_name, "Insert request rejected: " << e.what());
+                        return json_error(e.status_code(), e.what());
                     } catch(const std::runtime_error& e) {
                         LOG_WARN(1042, ctx.username, index_name, "Insert request rejected: " << e.what());
                         return json_error(400, e.what());
@@ -1045,6 +1051,9 @@ int main(int argc, char** argv) {
                             crow::response resp(200, std::string(sbuf.data(), sbuf.size()));
                             resp.add_header("Content-Type", "application/msgpack");
                             return resp;
+                        } catch(const ndd::ApiError& e) {
+                            LOG_WARN(1045, ctx.username, index_name, "Get-vector request failed: " << e.what());
+                            return json_error(e.status_code(), e.what());
                         } catch(const std::exception& e) {
                             LOG_DEBUG("Failed to get vector: " << e.what());
                             return json_error_500(ctx.username,
@@ -1072,6 +1081,9 @@ int main(int argc, char** argv) {
                         LOG_WARN(1046, ctx.username, index_name, "Delete-vector request for missing vector id " << vector_id);
                         return json_error(404, "Vector with the given ID does not exist");
                     }
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1047, ctx.username, index_name, "Delete-vector request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1047, ctx.username, index_name, "Delete-vector request rejected: " << e.what());
                     return json_error(400, e.what());
@@ -1116,6 +1128,9 @@ int main(int argc, char** argv) {
                             index_manager.deleteVectorsByFilter(index_id, filter_array);
 
                     return crow::response(200, std::to_string(deleted_count) + " vectors deleted");
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1051, ctx.username, index_name, "Delete-by-filter request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1051, ctx.username, index_name, "Delete-by-filter request rejected: " << e.what());
                     return json_error(400, e.what());
@@ -1165,6 +1180,9 @@ int main(int argc, char** argv) {
                     size_t count = index_manager.updateFilters(index_id, updates);
                     return crow::response(200, std::to_string(count) + " filters updated");
 
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1054, ctx.username, index_name, "Update-filters request rejected: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1054, ctx.username, index_name, "Update-filters request rejected: " << e.what());
                     return json_error(400, e.what());
@@ -1189,6 +1207,9 @@ int main(int argc, char** argv) {
                         return json_error(404, "Index does not exist");
                     }
                     return json_response(make_index_info_payload(*info));
+                } catch(const ndd::ApiError& e) {
+                    LOG_WARN(1056, ctx.username, index_name, "Index-info request failed: " << e.what());
+                    return json_error(e.status_code(), e.what());
                 } catch(const std::runtime_error& e) {
                     LOG_WARN(1056, ctx.username, index_name, "Index-info request failed: " << e.what());
                     return json_error(404, std::string("Error: ") + e.what());

--- a/src/storage/backup_store.hpp
+++ b/src/storage/backup_store.hpp
@@ -18,6 +18,7 @@
 #include "index_meta.hpp"
 #include "settings.hpp"
 #include "log.hpp"
+#include "../utils/errors.hpp"
 
 struct ActiveBackup {
     std::string index_id;
@@ -236,26 +237,22 @@ public:
 
     // Backup name validation
 
-    std::pair<bool, std::string> validateBackupName(const std::string& backup_name) const {
+    void validateBackupName(const std::string& backup_name) const {
         if(backup_name.empty()) {
-            return std::make_pair(false, "Backup name cannot be empty");
+            throw ndd::ApiError(400, "Backup name cannot be empty");
         }
 
         if(backup_name.length() > settings::MAX_BACKUP_NAME_LENGTH) {
-            return std::make_pair(false,
-                                  "Backup name too long (max "
-                                          + std::to_string(settings::MAX_BACKUP_NAME_LENGTH)
-                                          + " characters)");
+            throw ndd::ApiError(400, "Backup name too long (max "
+                                     + std::to_string(settings::MAX_BACKUP_NAME_LENGTH)
+                                     + " characters)");
         }
 
         static const std::regex backup_name_regex("^[a-zA-Z0-9_-]+$");
         if(!std::regex_match(backup_name, backup_name_regex)) {
-            return std::make_pair(false,
-                                  "Invalid backup name: only alphanumeric, underscores, "
-                                  "and hyphens allowed");
+            throw ndd::ApiError(400, "Invalid backup name: only alphanumeric, underscores, "
+                                     "and hyphens allowed");
         }
-
-        return std::make_pair(true, "");
     }
 
     // Backup listing
@@ -267,12 +264,9 @@ public:
 
     // Backup deletion
 
-    std::pair<bool, std::string> deleteBackup(const std::string& backup_name,
-                                               const std::string& username) {
-        std::pair<bool, std::string> result = validateBackupName(backup_name);
-        if(!result.first) {
-            return result;
-        }
+    void deleteBackup(const std::string& backup_name,
+                      const std::string& username) {
+        validateBackupName(backup_name);
 
         std::string backup_tar = getUserBackupDir(username) + "/" + backup_name + ".tar";
 
@@ -284,9 +278,8 @@ public:
             writeBackupJson(username, backup_db);
 
             LOG_INFO(1303, username, "Deleted backup " << backup_tar);
-            return {true, ""};
         } else {
-            return {false, "Backup not found"};
+            throw ndd::ApiError(404, "Backup not found");
         }
     }
 

--- a/src/utils/errors.hpp
+++ b/src/utils/errors.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <stdexcept>
+#include <string>
+
+namespace ndd {
+
+class ApiError : public std::runtime_error {
+private:
+    int status_code_;
+
+public:
+    ApiError(int status_code, const std::string& message)
+        : std::runtime_error(message), status_code_(status_code) {}
+
+    int status_code() const {
+        return status_code_;
+    }
+};
+
+} // namespace ndd


### PR DESCRIPTION
# Pull Request

## Summary

This PR addresses an issue where the API endpoints returned `400 Bad Request` for various operational failures (such as missing indexes or backup name conflicts). 

It introduces a centralized exception class, `ndd::ApiError`, which encapsulates the appropriate HTTP status codes. The core backend logic (`IndexManager` and `BackupStore`) has been updated to throw these exceptions rather than returning boolean pairs or generic runtime errors. The router (`main.cpp`) now catches these custom exceptions and relays the precise HTTP status code back to the client.


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [x] Refactor / cleanup

## Related Issue

Closes #249 

## Checklist

- [x] Code compiles and tests pass
- [ ] New tests added where applicable
- [ ] Documentation updated if needed
- [x] No unintended breaking changes
